### PR TITLE
NodeJS without $persist_dir

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -17,17 +17,7 @@
     "env_add_path": [ ".", "bin" ],
     "post_install": "
 # Set npm prefix to install modules inside bin
-Set-Content -Value \"prefix=$dir\\bin\" -Path $dir\\node_modules\\npm\\npmrc
-if (!(Test-Path \"$dir\\bin\\npm.cmd\")) {
-    Move-Item $dir\\npm $dir\\bin\\
-    Move-Item $dir\\npm.cmd $dir\\bin\\
-    Move-Item $dir\\node_modules $dir\\bin\\
-} else {
-    Remove-Item $dir\\npm
-    Remove-Item $dir\\npm.cmd
-    Remove-Item -r $dir\\node_modules
-}
-npm update -g",
+Set-Content -Value \"prefix=$dir\\bin\" -Path $dir\\node_modules\\npm\\npmrc",
     "checkver": {
         "url": "https://nodejs.org/en/download/current/",
         "re": "Current version: <strong>v([\\d.]+)</strong>"

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -12,11 +12,12 @@
             "hash": "2888f2303bcaa35f05b3dce7cbfee58af77dcea6bed4b9ff549b181c65eb4565"
         }
     },
-    "env_add_path": ["nodejs", "$persist_dir"],
-    "persist": "nodejs/node_modules",
+    "extract_dir": "nodejs",
+    "persist": [ "bin" ],
+    "env_add_path": [ ".", "bin" ],
     "post_install": "
-# Set npm prefix to install module inside $persist_dir
-Set-Content -Value \"prefix=$persist_dir\" -Path $persist_dir\\node_modules\\npm\\npmrc
+# Set npm prefix to install modules inside bin
+Set-Content -Value \"prefix=$dir\\bin\" -Path $dir\\node_modules\\npm\\npmrc
 npm update -g",
     "checkver": {
         "url": "https://nodejs.org/en/download/current/",

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -18,6 +18,15 @@
     "post_install": "
 # Set npm prefix to install modules inside bin
 Set-Content -Value \"prefix=$dir\\bin\" -Path $dir\\node_modules\\npm\\npmrc
+if (!(Test-Path \"$dir\\bin\\npm.cmd\")) {
+    Move-Item $dir\\npm $dir\\bin\\
+    Move-Item $dir\\npm.cmd $dir\\bin\\
+    Move-Item $dir\\node_modules $dir\\bin\\
+} else {
+    Remove-Item $dir\\npm
+    Remove-Item $dir\\npm.cmd
+    Remove-Item -r $dir\\node_modules
+}
 npm update -g",
     "checkver": {
         "url": "https://nodejs.org/en/download/current/",

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -755,6 +755,9 @@ function unlink_current($versiondir) {
     if(test-path $currentdir) {
         write-host "Unlinking $(friendly_path $currentdir)"
 
+        # remove read-only attribute on link
+        attrib $currentdir -R /L
+
         # remove the junction
         cmd /c rmdir $currentdir
         return $currentdir

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -739,6 +739,7 @@ function link_current($versiondir) {
     }
 
     cmd /c mklink /j $currentdir $versiondir | out-null
+    attrib $currentdir +R /L
     return $currentdir
 }
 
@@ -985,12 +986,13 @@ function persist_data($manifest) {
             $persist = @($persist);
         }
 
-        write-host "Persisting $persist"
         $persist | % {
             $source, $target = persist_def $_
 
+            write-host "Persisting $source"
+
             # add base paths
-            $source = "$(resolve-path $original_dir\$source)"
+            $source = fullpath "$dir\$source"
             $target = fullpath "$persist_dir\$target"
 
             if (!(test-path $target)) {
@@ -999,7 +1001,7 @@ function persist_data($manifest) {
                     Move-Item $source $target
                 } else {
                     # if there is no source we create an empty directory
-                    ensure $target
+                    $target = ensure $target
                 }
             } elseif (test-path $source) {
                 # (re)move original (keep a copy)
@@ -1009,7 +1011,7 @@ function persist_data($manifest) {
             # create link
             if (is_directory $target) {
                 cmd /c "mklink /j $source $target" | out-null
-                attrib $source +R /L #
+                attrib $source +R /L
             } else {
                 cmd /c "mklink /h $source $target" | out-null
             }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -762,7 +762,7 @@ function unlink_current($versiondir) {
         cmd /c rmdir $currentdir
         return $currentdir
     }
-    return $appdir
+    return $versiondir
 }
 
 # to undo after installers add to path so that scoop manifest can keep track of this instead

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -135,6 +135,12 @@ function update($app, $global, $quiet = $false, $independent, $suggested) {
     rm_shims $old_manifest $global $architecture
     env_rm_path $old_manifest $dir $global
     env_rm $old_manifest $global
+
+    # If a junction was used during install, that will have been used
+    # as the reference directory. Otherwise it will just be the version
+    # directory.
+    $refdir = unlink_current $dir
+
     # note: keep the old dir in case it contains user files
 
     install_app $app $architecture $global $suggested


### PR DESCRIPTION
How about this? It's an alternative NodeJS manifest using persistence but without requiring the `$persist_dir` variable in `env_add_path` or `post_install`.

This way, we can keep the complexities of persisted directories hidden from manifest authors and users (reducing the learning curve).

This change would also make it unnecessary for the workaround to check for `$` variables in `prepare_env_path`.

From a user's point of view, they would just need to know that the current version of NodeJS is installed at `~/scoop/apps/nodejs/current`, any path or other environment variables will reference this too, and the `bin` directory inside that `current` directory will be persisted across updates.

Perhaps this would also help us avoid having to add complicated source and target definitions in `persist` to move files, as you suggested might be necessary in future. I would much prefer to keep things simple, if possible. 

Ref: lukesampson/scoop#1372.